### PR TITLE
ゆるゆりSS速報を削除するPatch作成

### DIFF
--- a/app/models/blog.rb
+++ b/app/models/blog.rb
@@ -12,7 +12,7 @@
 #
 
 class Blog < ApplicationRecord
-  has_many :articles
+  has_many :articles, :dependent => :delete_all
 
   def fetch_rss
     # RSS 未登録はスキップ
@@ -36,7 +36,10 @@ class Blog < ApplicationRecord
     Article.create_with_story_from_entry(self, entry, tags)
   end
 
-  def patch_delete_all
-    # TODO:
+
+
+  after_destroy do
+    Story.left_outer_joins(:articles).where( articles: { id: nil } ).destroy_all()
   end
+
 end

--- a/app/models/blog.rb
+++ b/app/models/blog.rb
@@ -35,4 +35,8 @@ class Blog < ApplicationRecord
 
     Article.create_with_story_from_entry(self, entry, tags)
   end
+
+  def patch_delete_all
+    # TODO:
+  end
 end

--- a/lib/tasks/patch.rake
+++ b/lib/tasks/patch.rake
@@ -8,17 +8,29 @@ namespace :patch do
     end
   end
 
-  task :remove_yuruyuri_blog => :environment do
+  # ゆるゆりSS速報のarticleを削除
+  task :remove_article_yryr => :environment do
+    delete_article_count = 0
+    delete_story_count = 0
     Story.includes(:articles).each do |story|
+      articles_count = story.articles.size
       story.articles.each do |article|
         if article.blog.title == 'ゆるゆりSS速報'
-          article.destroy!
+          article.destroy
+          articles_count -= 1
+          p "#{article.blog.title}削除成功"
+          delete_article_count += 1
         end
       end
-      if story.articles.size == 0
+      if articles_count == 0
         story.destroy
+        p "Remove #{story.title}"
+        delete_story_count += 1
       end
-      p "Remove #{story.title}"
     end
+    puts
+    puts
+    p "#{delete_article_count}個のarticleを削除して、"
+    p "#{delete_story_count}個のstoryを削除した"
   end
 end

--- a/lib/tasks/patch.rake
+++ b/lib/tasks/patch.rake
@@ -10,26 +10,14 @@ namespace :patch do
 
   # ゆるゆりSS速報のarticleを削除
   task :remove_article_yryr => :environment do
-    delete_article_count = 0
-    delete_story_count = 0
-    Story.includes(:articles).each do |story|
-      articles_count = story.articles.size
-      story.articles.each do |article|
-        if article.blog.title == 'ゆるゆりSS速報'
-          article.destroy
-          articles_count -= 1
-          p "#{article.blog.title}削除成功"
-          delete_article_count += 1
-        end
-      end
-      if articles_count == 0
-        story.destroy
-        p "Remove #{story.title}"
-        delete_story_count += 1
-      end
-    end
-    puts
-    puts
+    blog = Blog.find_by(title: 'ゆるゆり速報')
+    ac = Article.count
+    sc = Story.count
+
+    blog.delete_all()
+
+    delete_article_count = ac - Article.count
+    delete_story_count = sc - Story.count
     p "#{delete_article_count}個のarticleを削除して、"
     p "#{delete_story_count}個のstoryを削除した"
   end

--- a/lib/tasks/patch.rake
+++ b/lib/tasks/patch.rake
@@ -14,7 +14,7 @@ namespace :patch do
     ac = Article.count
     sc = Story.count
 
-    blog.delete_all()
+    blog.destroy()
 
     delete_article_count = ac - Article.count
     delete_story_count = sc - Story.count

--- a/lib/tasks/patch.rake
+++ b/lib/tasks/patch.rake
@@ -7,4 +7,18 @@ namespace :patch do
       p "Remove #{story.title}"
     end
   end
+
+  task :remove_yuruyuri_blog => :environment do
+    Story.includes(:articles).each do |story|
+      story.articles.each do |article|
+        if article.blog.title == 'ゆるゆりSS速報'
+          article.destroy!
+        end
+      end
+      if story.articles.size == 0
+        story.destroy
+      end
+      p "Remove #{story.title}"
+    end
+  end
 end

--- a/spec/models/blog_spec.rb
+++ b/spec/models/blog_spec.rb
@@ -14,4 +14,40 @@
 require 'rails_helper'
 
 describe Blog do
+
+  describe '#patch_delete_all' do
+    before do
+      blogM = create(:blog_mode_ss)
+      @blogY = create(:blog_yryr)
+
+      @story =create(:story, :title => 'titleA')
+      tags = %w(tagA tagB tagC)
+      @story.regist_tags(tags)
+      @a1 = create(:article, :story => @story, :blog => @blogY)
+
+      @storyB =create(:story, :title => 'titleB')
+      tags = %w(tagA tagB tagC)
+      @storyB.regist_tags(tags)
+      @a2 = create(:article, :story => @storyB, :blog => @blogY)
+      @a3 = create(:article, :story => @storyB, :blog => blogM)
+
+      # Bomb!
+      @blogY.patch_delete_all()
+    end
+
+    it 'ブログ削除が正常に行われた' do
+      expect(@blogY).to be_nil
+    end
+
+    it 'ひもづく Articles が消えている' do
+      expect(@a1).to be_nil
+      expect(@a2).to be_nil
+      expect(@a3).not_to be_nil
+    end
+
+    it '消えるべき Story だけ消えている' do
+      expect(@story).to be_nil
+      expect(@storyB).not_to be_nil
+    end
+  end
 end

--- a/spec/models/blog_spec.rb
+++ b/spec/models/blog_spec.rb
@@ -15,7 +15,7 @@ require 'rails_helper'
 
 describe Blog do
 
-  describe '#patch_delete_all' do
+  describe '#destroy' do
     before do
       blogM = create(:blog_mode_ss)
       @blogY = create(:blog_yryr)

--- a/spec/models/blog_spec.rb
+++ b/spec/models/blog_spec.rb
@@ -32,22 +32,22 @@ describe Blog do
       @a3 = create(:article, :story => @storyB, :blog => blogM)
 
       # Bomb!
-      @blogY.patch_delete_all()
+      @blogY.destroy()
     end
 
     it 'ブログ削除が正常に行われた' do
-      expect(@blogY).to be_nil
+      expect(@blogY.destroyed?).to be_truthy
     end
 
     it 'ひもづく Articles が消えている' do
-      expect(@a1).to be_nil
-      expect(@a2).to be_nil
-      expect(@a3).not_to be_nil
+      expect(Article.where(id: @a1.id)).not_to exist
+      expect(Article.where(id: @a2.id)).not_to exist
+      expect(Article.where(id: @a3.id)).to exist
     end
 
     it '消えるべき Story だけ消えている' do
-      expect(@story).to be_nil
-      expect(@storyB).not_to be_nil
+      expect(Story.where(id: @story.id)).not_to exist
+      expect(Story.where(id: @storyB.id)).to exist
     end
   end
 end


### PR DESCRIPTION
## patchの機能
* 全storyの中からゆるゆりSS速報のarticleを削除
* 削除によってarticleの数が0になったstoryの削除

## テスト
```
urlY = "http:yryr/1"
posted_atY = "2010-08-30T16:00:48.000Z"
blogY = Blog.find_by(title: 'ゆるゆりSS速報')
titleY = "京子「あかりにドッキリ」"
titleYY = "櫻子「ひまわりにドッキリ」"
tagsY = ["ゆるゆり"]

urlE = "http:elephant/1"
posted_atE = "2010-08-31T16:00:48.000Z"
blogE = Blog.find_by(title: 'エレファント速報')
titleE = "京子「あかりにドッキリ」"
tagsE = ["百合"]

Article.create_with_story(urlY, posted_atY, blogY, titleY, tagsY)
Article.create_with_story(urlE, posted_atE, blogE, titleE, tagsE)
Article.create_with_story(urlY, posted_atY, blogY, titleYY, tagsY)
```
上のデータを`$ rails console`で入力して、
`bin/rails patch:remove_article_yryr`にて実行